### PR TITLE
Added an abstraction over ResizeListener to make it easier to double in tests

### DIFF
--- a/BlazorSize.CsbExample/Pages/Index.razor
+++ b/BlazorSize.CsbExample/Pages/Index.razor
@@ -1,5 +1,5 @@
 ﻿@implements IDisposable
-@inject ResizeListener listener
+@inject IResizeListener listener
 @page "/"
 
 <h3>Height: @browser.Height</h3>

--- a/BlazorSize.Example/Pages/Index.razor
+++ b/BlazorSize.Example/Pages/Index.razor
@@ -1,5 +1,5 @@
 ﻿@implements IDisposable
-@inject ResizeListener listener
+@inject IResizeListener listener
 @page "/"
 
 <h3>Height: @browser.Height</h3>

--- a/BlazorSize.ExampleNet5/Program.cs
+++ b/BlazorSize.ExampleNet5/Program.cs
@@ -22,7 +22,7 @@ namespace BlazorSize.ExampleNet5
 
             builder.Services.AddScoped<WeatherForecastService>();
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-            builder.Services.AddScoped<ResizeListener>();
+            builder.Services.AddResizeListener();
             builder.Services.AddSingleton<IWeatherForecastService, WeatherForecastService>();
 
             await builder.Build().RunAsync();

--- a/BlazorSize/BlazorPro.BlazorSize.csproj
+++ b/BlazorSize/BlazorPro.BlazorSize.csproj
@@ -5,6 +5,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>9.0</LangVersion>
+    <Nullable>Enable</Nullable>
     <Version>3.1.0</Version>
     <Authors>Ed Charbeneau</Authors>
     <Company>EdCharbeneau.com</Company>

--- a/BlazorSize/Configuration/ServiceCollectionExtensions.cs
+++ b/BlazorSize/Configuration/ServiceCollectionExtensions.cs
@@ -8,13 +8,16 @@ namespace BlazorPro.BlazorSize
         /// <summary>
         /// Adds a BlazorSize.ResizeListener as a Scoped instance.
         /// </summary>
-        /// <param name="configure">Defines settings for this instance.</param>
+        /// <param name="resizeOptions">Defines settings for this instance.</param>
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddResizeListener(this IServiceCollection services,
-            Action<ResizeOptions> configure)
+            Action<ResizeOptions>? resizeOptions = null)
         {
-            services.AddScoped<ResizeListener>();
-            services.Configure(configure);
+            services.AddScoped<IResizeListener, ResizeListener>();
+         
+            if(resizeOptions is not null)
+                services.Configure(resizeOptions);
+            
             return services;
         }
     }

--- a/BlazorSize/MediaQuery/MediaQueryList.razor.cs
+++ b/BlazorSize/MediaQuery/MediaQueryList.razor.cs
@@ -94,6 +94,8 @@ namespace BlazorPro.BlazorSize
             // DOM Media value my be different that the initally requested media query value.
             var cache = mediaQueries.Find(q => q.Value.Media == args.Media);
 
+            if (cache is null) return;
+
             // Dispatch events to all subscribers
             foreach (var item in cache.MediaQueries)
             {

--- a/BlazorSize/Resize/IResizeListener.cs
+++ b/BlazorSize/Resize/IResizeListener.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace BlazorPro.BlazorSize
+{
+    public interface IResizeListener
+    {
+        event EventHandler<BrowserWindowSize> OnResized;
+        ValueTask<BrowserWindowSize> GetBrowserWindowSize();
+        ValueTask<bool> MatchMedia(string mediaQuery);
+    }
+}

--- a/BlazorSize/Resize/ResizeListener.cs
+++ b/BlazorSize/Resize/ResizeListener.cs
@@ -6,12 +6,13 @@ using System.Threading.Tasks;
 
 namespace BlazorPro.BlazorSize
 {
-    public class ResizeListener : IDisposable
+    internal class ResizeListener : IResizeListener, IDisposable
     {
         const string ns = "blazorSize";
         private readonly IJSRuntime jsRuntime;
         private readonly ResizeOptions options;
         private bool disposed;
+
         public ResizeListener(IJSRuntime jsRuntime, IOptions<ResizeOptions> options = null)
         {
             this.options = options.Value ?? new ResizeOptions();

--- a/BlazorSize/Resize/ResizeListener.net5.cs
+++ b/BlazorSize/Resize/ResizeListener.net5.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 namespace BlazorPro.BlazorSize
 {
-    public class ResizeListener : IAsyncDisposable
+    internal class ResizeListener : IResizeListener, IAsyncDisposable
     {
         private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 
         private readonly ResizeOptions options;
         
         private bool disposed;
-        public ResizeListener(IJSRuntime jsRuntime, IOptions<ResizeOptions> options = null)
+        public ResizeListener(IJSRuntime jsRuntime, IOptions<ResizeOptions>? options = null)
         {
-            this.options = options.Value ?? new ResizeOptions();
+            this.options = options?.Value ?? new ResizeOptions();
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>(
                         "import", "./_content/BlazorPro.BlazorSize/blazorSizeResizeModule.js").AsTask());
         }
@@ -31,18 +31,18 @@ namespace BlazorPro.BlazorSize
             remove => Unsubscribe(value);
         }
 
-        private void Unsubscribe(EventHandler<BrowserWindowSize> value)
+        private void Unsubscribe(EventHandler<BrowserWindowSize>? value)
         {
             onResized -= value;
-            if (onResized == null)
+            if (onResized is null)
             {
                 Cancel().ConfigureAwait(false);
             }
         }
 
-        private void Subscribe(EventHandler<BrowserWindowSize> value)
+        private void Subscribe(EventHandler<BrowserWindowSize>? value)
         {
-            if (onResized == null)
+            if (onResized is null)
             {
                 Task.Run(async () => await Start());
             }

--- a/TestComponents/Pages/Index.razor
+++ b/TestComponents/Pages/Index.razor
@@ -1,5 +1,5 @@
 ﻿@implements IDisposable
-@inject ResizeListener listener
+@inject IResizeListener listener
 @page "/"
 
 <h3>Height: @browser.Height</h3>


### PR DESCRIPTION
To make it easier to fake or mock the resize listener while testing
components that use it, I have introduced a IResizeListener with the
relevant public methods.

This is a breaking change because users will have to switch from injecting
ResizeListener to IResizeListener, since ResizeListener has also been
marked internal. This makes it easier to change the library in the future,
as users cannot use methods/properties/features they are not intented to use.

I also enabled nullable on the project and resolved a few of the resulting
warnings. However, there are still some left, but didnt want go to deep.

Ps. I was not able to get the demo apps to work du to JS errors,
neither before nor after my changes. Perhaps I am missing some build
tools for the JavaScript?
