### PR TITLE
Remove bunit.core dependency

### DIFF
--- a/BlazorSize/BlazorPro.BlazorSize.csproj
+++ b/BlazorSize/BlazorPro.BlazorSize.csproj
@@ -70,7 +70,6 @@
     <Content Include="*.ts">
       <Pack>False</Pack>
     </Content>
-    <PackageReference Include="bunit.core" Version="1.3.42" />
     <Content Update="*.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <Pack>False</Pack>


### PR DESCRIPTION
The BlazorPro.BlazorSize project pulls in the bunit.core dependency for no apparent reason. (I assume it's a leftover by mistake.) This should be removed, so Blazor WASM apps using BlazorSize won't have an indirect dependency on bunit.core which unnecessarily increases app download size - which is an issue for Blazor WASM apps anyway.