### PR TITLE
Use proper js invocation return type within ResizeListener.Start

### DIFF
--- a/BlazorSize/Resize/ResizeListener.cs
+++ b/BlazorSize/Resize/ResizeListener.cs
@@ -48,10 +48,10 @@ namespace BlazorPro.BlazorSize
             onResized += value;
         }
 
-        private async ValueTask<bool> Start()
+        private async ValueTask Start()
         {
             var module = await moduleTask.Value;
-            return await module.InvokeAsync<bool>("listenForResize", DotNetObjectReference.Create(this), options);
+            await module.InvokeVoidAsync("listenForResize", DotNetObjectReference.Create(this), options);
         }
 
         private async ValueTask Cancel()


### PR DESCRIPTION
Hi Ed,

```
[Inject] private IResizeListener ResizeListener { get; set; } = default!;

protected override void OnInitialized()
{
    base.OnInitialized();
    ResizeListener.OnResized += ResizeListener_OnResized;
}
```

causes the following exception. you will only see the exception if you catch UnobservedTaskExceptions, as well as waiting for the GC to pick up the faulted task.

`System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (An exception occurred executing JS interop: The JSON value could not be converted to System.Boolean. Path: $ | LineNumber: 0 | BytePositionInLine: 4.. See InnerException for more details.)
 ---> Microsoft.JSInterop.JSException: An exception occurred executing JS interop: The JSON value could not be converted to System.Boolean. Path: $ | LineNumber: 0 | BytePositionInLine: 4.. See InnerException for more details.
 ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Boolean. Path: $ | LineNumber: 0 | BytePositionInLine: 4.
 ---> System.InvalidOperationException: Cannot get the value of a token type 'Null' as a boolean.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ExpectedBoolean(JsonTokenType tokenType)
   at System.Text.Json.Serialization.Converters.BooleanConverter.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Deserialize(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsObject(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadAsObject(Utf8JsonReader& reader, JsonTypeInfo jsonTypeInfo)
   at Microsoft.JSInterop.JSRuntime.EndInvokeJS(Int64 taskId, Boolean succeeded, Utf8JsonReader& jsonReader)
   --- End of inner exception stack trace ---
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at BlazorPro.BlazorSize.ResizeListener.Start()
   at BlazorPro.BlazorSize.ResizeListener.<Subscribe>b__9_0()
   --- End of inner exception stack trace ---`


issue was fixed for me, by using the provided code.